### PR TITLE
docs: add house-style status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # ood-braket-adapter
 
+[![CI](https://github.com/scttfrdmn/ood-braket-adapter/actions/workflows/ci.yml/badge.svg)](https://github.com/scttfrdmn/ood-braket-adapter/actions/workflows/ci.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/scttfrdmn/ood-braket-adapter)](https://goreportcard.com/report/github.com/scttfrdmn/ood-braket-adapter)
+[![codecov](https://codecov.io/gh/scttfrdmn/ood-braket-adapter/branch/main/graph/badge.svg)](https://codecov.io/gh/scttfrdmn/ood-braket-adapter)
+[![Go Reference](https://pkg.go.dev/badge/github.com/scttfrdmn/ood-braket-adapter.svg)](https://pkg.go.dev/github.com/scttfrdmn/ood-braket-adapter)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 Open OnDemand adapter for [Amazon Braket](https://aws.amazon.com/braket/) — submit,
 monitor, and cancel quantum tasks on QPUs and managed simulators from the OOD portal.
 


### PR DESCRIPTION
Adds the ecosystem house-style status badges to the README header: **CI**, **Go Report Card**, **codecov**, **Go Reference** (pkg.go.dev), and **License: MIT**.

Matches the badge level used across the spore-host projects, adapted to this Go adapter. MIT badge reflects the OOD ecosystem license (Open OnDemand itself is MIT). Docs-only.